### PR TITLE
Fixing ping command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nfv-test-api"
-version = "1.0.0"
+version = "1.0.1"
 description = "API for testing network functions."
 authors = ["Inmanta <code@inmanta.com>"]
 license = "Apache-2.0"

--- a/src/nfv_test_api/v2/services/actions.py
+++ b/src/nfv_test_api/v2/services/actions.py
@@ -35,7 +35,7 @@ class ActionsService:
             "-c",
             str(ping_request.count),
             "-i",
-            str(ping_request.interval).replace(".", ","),
+            str(ping_request.interval),
         ]
         if ping_request.interface is not None:
             command += ["-I", str(ping_request.interface)]


### PR DESCRIPTION
# In this PR

Fixed issue with ping command in api v2.  Depending on the version of ping, the interval argument format changes.  The api has been aligned to the version that will be installed in the container.

Closes #28