### PR TITLE
Issue/25 move interface

### DIFF
--- a/src/nfv_test_api/v2/data/interface.py
+++ b/src/nfv_test_api/v2/data/interface.py
@@ -17,7 +17,6 @@ from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface
 from typing import List, Optional, Union
 
-from pydantic import BaseModel
 from typing_extensions import Literal
 
 from .base_model import IpBaseModel
@@ -104,6 +103,7 @@ class InterfaceCreate(IpBaseModel):
     address: Optional[Union[IPv4Interface, IPv6Interface]]
     broadcast: Optional[Union[IPv4Address, IPv6Address]]
     type: LinkInfo.Kind = LinkInfo.Kind.VETH
+    peer: Optional[SafeName]  # type: ignore
     slave_interfaces: Optional[List[SafeName]]  # type: ignore
 
 

--- a/src/nfv_test_api/v2/data/interface.py
+++ b/src/nfv_test_api/v2/data/interface.py
@@ -93,7 +93,7 @@ class InterfaceState(str, Enum):
     LOWERLAYERDOWN = "LOWERLAYERDOWN"
 
 
-class InterfaceCreate(BaseModel):
+class InterfaceCreate(IpBaseModel):
     """
     Input schema for creating an interface
     """
@@ -107,7 +107,7 @@ class InterfaceCreate(BaseModel):
     slave_interfaces: Optional[List[SafeName]]  # type: ignore
 
 
-class InterfaceUpdate(BaseModel):
+class InterfaceUpdate(IpBaseModel):
     """
     Input schema for updating an interface.
 

--- a/src/nfv_test_api/v2/data/namespace.py
+++ b/src/nfv_test_api/v2/data/namespace.py
@@ -15,8 +15,6 @@
 """
 from typing import Optional
 
-from pydantic import BaseModel
-
 from .base_model import IpBaseModel
 from .common import SafeName
 

--- a/src/nfv_test_api/v2/data/namespace.py
+++ b/src/nfv_test_api/v2/data/namespace.py
@@ -21,7 +21,7 @@ from .base_model import IpBaseModel
 from .common import SafeName
 
 
-class NamespaceCreate(BaseModel):
+class NamespaceCreate(IpBaseModel):
     """
     Input for creating a network namespace
 
@@ -32,7 +32,7 @@ class NamespaceCreate(BaseModel):
     ns_id: Optional[int]
 
 
-class NamespaceUpdate(BaseModel):
+class NamespaceUpdate(IpBaseModel):
     """
     Input for updating a network namespace
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@
 """
 import logging
 import os
-import subprocess
 import threading
 import time
 import uuid
@@ -74,7 +73,9 @@ def nfv_test_api_image(docker_client: docker.DockerClient, free_image_tag: str) 
 
 
 @pytest.fixture(scope="function")
-def nfv_test_api_instance(docker_client: docker.DockerClient, nfv_test_api_image: images.Image) -> Generator[containers.Container, None, None]:
+def nfv_test_api_instance(
+    docker_client: docker.DockerClient, nfv_test_api_image: images.Image
+) -> Generator[containers.Container, None, None]:
     """
     This fixture create and starts a container running the nfv-test-api and returns it api object.
     """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -20,7 +20,7 @@ import requests
 LOGGER = logging.getLogger(__name__)
 
 
-def test_get_interfaces(nfv_test_api_instance: str) -> None:
+def test_get_interfaces(nfv_test_api_endpoint: str) -> None:
     # Get all the interfaces of the container
-    response = requests.get(f"{nfv_test_api_instance}/interfaces")
+    response = requests.get(f"{nfv_test_api_endpoint}/interfaces")
     response.raise_for_status()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,62 @@
+"""
+       Copyright 2021 Inmanta
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+from ipaddress import IPv4Interface
+import logging
+
+import requests
+
+from nfv_test_api.v2.data.interface import Addr4Info, Interface, InterfaceCreate, InterfaceState, InterfaceUpdate
+from nfv_test_api.v2.data.namespace import NamespaceCreate, Namespace
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_25_move_interface(nfv_test_api_instance: str) -> None:
+    # Create a new interface
+    new_interface = InterfaceCreate(
+        name="test",
+        address=IPv4Interface("255.255.255.1/2"),
+    )
+    response = requests.post(f"{nfv_test_api_instance}/interfaces", json=new_interface.json_dict())
+    response.raise_for_status()
+
+    created_interface = Interface(**response.json())
+
+    # Bring the interface up
+    patch_interface = InterfaceUpdate(
+        state=InterfaceState.UP,
+    )
+    response = requests.patch(f"{nfv_test_api_instance}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response.raise_for_status()
+
+    updated_interface = Interface(**response.json())
+    assert updated_interface.oper_state == patch_interface.state
+
+    # Create a new namespace
+    new_namespace = NamespaceCreate(
+        name="test",
+    )
+    response = requests.post(f"{nfv_test_api_instance}/namespaces", json=new_namespace.json_dict())
+    response.raise_for_status()
+
+    created_namespace = Namespace(**response.json())
+
+    # Move interface in new namespace
+    patch_interface = InterfaceUpdate(
+        netns=created_namespace.ns_id,
+    )
+    response = requests.patch(f"{nfv_test_api_instance}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response.raise_for_status()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -24,32 +24,29 @@ from nfv_test_api.v2.data.namespace import NamespaceCreate, Namespace
 LOGGER = logging.getLogger(__name__)
 
 
-def test_25_move_interface(nfv_test_api_instance: str) -> None:
+def test_25_move_interface(nfv_test_api_endpoint: str, nfv_test_api_logs: None) -> None:
     # Create a new interface
     new_interface = InterfaceCreate(
         name="test",
-        address=IPv4Interface("255.255.255.1/2"),
     )
-    response = requests.post(f"{nfv_test_api_instance}/interfaces", json=new_interface.json_dict())
+    response = requests.post(f"{nfv_test_api_endpoint}/interfaces", json=new_interface.json_dict())
     response.raise_for_status()
 
     created_interface = Interface(**response.json())
 
-    # Bring the interface up
+    # Set the interface address and bring the interface up
     patch_interface = InterfaceUpdate(
+        addresses=[IPv4Interface("192.168.15.2/24")],
         state=InterfaceState.UP,
     )
-    response = requests.patch(f"{nfv_test_api_instance}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
     response.raise_for_status()
-
-    updated_interface = Interface(**response.json())
-    assert updated_interface.oper_state == patch_interface.state
 
     # Create a new namespace
     new_namespace = NamespaceCreate(
         name="test",
     )
-    response = requests.post(f"{nfv_test_api_instance}/namespaces", json=new_namespace.json_dict())
+    response = requests.post(f"{nfv_test_api_endpoint}/namespaces", json=new_namespace.json_dict())
     response.raise_for_status()
 
     created_namespace = Namespace(**response.json())
@@ -58,5 +55,5 @@ def test_25_move_interface(nfv_test_api_instance: str) -> None:
     patch_interface = InterfaceUpdate(
         netns=created_namespace.ns_id,
     )
-    response = requests.patch(f"{nfv_test_api_instance}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
     response.raise_for_status()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -13,13 +13,19 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from ipaddress import IPv4Interface
 import logging
+from ipaddress import IPv4Interface
 
 import requests
 
-from nfv_test_api.v2.data.interface import Addr4Info, Interface, InterfaceCreate, InterfaceState, InterfaceUpdate
-from nfv_test_api.v2.data.namespace import NamespaceCreate, Namespace
+from nfv_test_api.v2.data.interface import (
+    Interface,
+    InterfaceCreate,
+    InterfaceState,
+    InterfaceUpdate,
+    LinkInfo,
+)
+from nfv_test_api.v2.data.namespace import Namespace, NamespaceCreate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,33 +33,53 @@ LOGGER = logging.getLogger(__name__)
 def test_25_move_interface(nfv_test_api_endpoint: str, nfv_test_api_logs: None) -> None:
     # Create a new interface
     new_interface = InterfaceCreate(
-        name="test",
+        name="test0",
+        type=LinkInfo.Kind.VETH,
+        peer="test1",
     )
     response = requests.post(f"{nfv_test_api_endpoint}/interfaces", json=new_interface.json_dict())
+    LOGGER.debug(response.json())
     response.raise_for_status()
 
     created_interface = Interface(**response.json())
 
-    # Set the interface address and bring the interface up
+    # Set the first interface address and bring the interface up
     patch_interface = InterfaceUpdate(
         addresses=[IPv4Interface("192.168.15.2/24")],
         state=InterfaceState.UP,
     )
-    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/test0", json=patch_interface.json_dict())
+    LOGGER.debug(response.json())
     response.raise_for_status()
+
+    # Set the second interface address and bring the interface up
+    patch_interface = InterfaceUpdate(
+        addresses=[IPv4Interface("192.168.15.3/24")],
+        state=InterfaceState.UP,
+    )
+    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/test1", json=patch_interface.json_dict())
+    LOGGER.debug(response.json())
+    response.raise_for_status()
+
+    updated_interface = Interface(**response.json())
+    assert updated_interface.oper_state == InterfaceState.UP
 
     # Create a new namespace
     new_namespace = NamespaceCreate(
         name="test",
     )
     response = requests.post(f"{nfv_test_api_endpoint}/namespaces", json=new_namespace.json_dict())
+    LOGGER.debug(response.json())
     response.raise_for_status()
 
     created_namespace = Namespace(**response.json())
 
     # Move interface in new namespace
     patch_interface = InterfaceUpdate(
-        netns=created_namespace.ns_id,
+        netns=created_namespace.name,
     )
-    response = requests.patch(f"{nfv_test_api_endpoint}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict())
+    response = requests.patch(
+        f"{nfv_test_api_endpoint}/interfaces/{created_interface.if_name}", json=patch_interface.json_dict()
+    )
+    LOGGER.debug(response.json())
     response.raise_for_status()


### PR DESCRIPTION
1. Added support for peer of interfaces (this allows to create movable interface with a real end in the container)
2. Added test case to reproduce the issue described in the ticket (moved interface raise a 404)
3. Fixed api, all operations on an interface will now reload the interface using the host the interface is in (this is not the original solution, this one is less generic and elegant but requires way less changes)

Closes #25 