### PR TITLE
Ping timeout added

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.2
+current_version = 2.5.3
 tag = False
 commit = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-nfv-test-api
-version = 2.5.2
+version = 2.5.3
 description = API for testing network functions.
 author = Inmanta
 author_email = code@inmanta.com

--- a/src/nfv_test_api/__init__.py
+++ b/src/nfv_test_api/__init__.py
@@ -13,4 +13,4 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-__version__ = "2.5.2"
+__version__ = "2.5.3"

--- a/src/nfv_test_api/v2/data/ping.py
+++ b/src/nfv_test_api/v2/data/ping.py
@@ -28,6 +28,7 @@ class PingRequest(BaseModel):
     interface: Optional[Union[SafeName, IPv4Interface, IPv6Interface]]  # type: ignore
     count: int = 4
     interval: float = 0.5
+    timeout: int = 8
 
 
 class Ping(IpBaseModel):

--- a/src/nfv_test_api/v2/services/actions.py
+++ b/src/nfv_test_api/v2/services/actions.py
@@ -34,6 +34,8 @@ class ActionsService:
             "ping",
             "-c",
             str(ping_request.count),
+            "-w",
+            str(ping_request.timeout),
             "-i",
             str(ping_request.interval),
         ]
@@ -44,6 +46,7 @@ class ActionsService:
         stdout, stderr = self.host.exec(command)
 
         if stderr:
+            LOGGER.error("Ping stderr: %s", stderr)
             if not stdout:
                 raise RuntimeError(f"Failed to execute ping command: {stderr}")
 
@@ -54,5 +57,5 @@ class ActionsService:
             return Ping(**ping_result)  # type: ignore
         except ValidationError as e:
             LOGGER.error("Failed to parse ping response: %s", ping_result)
-            LOGGER.error("Failed to ping: %s", stdout)
+            LOGGER.error("Ping stdout: %s", stdout)
             raise e

--- a/src/pytest_nfv_test_api/__init__.py
+++ b/src/pytest_nfv_test_api/__init__.py
@@ -27,7 +27,7 @@ from docker.models import containers, images  # type: ignore
 
 LOGGER = logging.getLogger(__name__)
 
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

The host exec function timeouts after 10 seconds, which makes the ping stdout and stderr empty in case of unreachable destination. This is now fixed by setting a smaller timeout in the ping command.

# Reviewers list 

- [ ] @guillaume.everartsdevelp 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Correct, in line with design
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented (classes, methods and function docs, document important assumptions, link to reference materials)
- [ ] Type annotations
- [ ] Issue is in the review column
- [x] MR is assigned to first reviewer